### PR TITLE
[Config] Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# STAGE 1
+FROM rust:1.62 AS builder
+# Install dependencies
+RUN apt update
+# Copy source code.
+COPY src /src
+COPY Cargo.toml Cargo.lock /
+# Build rust binaries.
+RUN cargo build --release --manifest-path /Cargo.toml
+
+# STAGE 2
+FROM ubuntu:20.04 as base
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/New_York
+# Install dependencies
+RUN apt update
+# Copy only the worker binary and execute.
+COPY --from=builder /target/release/algo3_backend /algo3_backend
+# Expose port.
+EXPOSE 80
+# Run binaries
+CMD ["/algo3_backend"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
 # STAGE 1
-FROM rust:1.62 AS builder
+FROM rust:alpine3.15 AS builder
+
 # Install dependencies
-RUN apt update
+RUN apk add musl-dev --no-cache
+
 # Copy source code.
 COPY src /src
 COPY Cargo.toml Cargo.lock /
+
 # Build rust binaries.
 RUN cargo build --release --manifest-path /Cargo.toml
 
 # STAGE 2
-FROM ubuntu:20.04 as base
-ARG DEBIAN_FRONTEND=noninteractive
-ENV TZ=America/New_York
-# Install dependencies
-RUN apt update
+FROM alpine:3.15 as base
 # Copy only the worker binary and execute.
 COPY --from=builder /target/release/algo3_backend /algo3_backend
 # Expose port.
 EXPOSE 80
 # Run binaries
-CMD ["/algo3_backend"]
+CMD ["./algo3_backend"]

--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,4 @@ build_docker:
 	docker build -t algo3_backend . --no-cache
 
 run_docker:
-	docker run --rm -p ${FROM}:80 algo3_backend -d
+	docker run --rm -p ${FROM}:80 -d algo3_backend

--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,5 @@ test_get_queue:
 build_docker:
 	docker build -t algo3_backend .
 
-run_docker:
+run_docker: build_docker
 	docker run --rm -p ${FROM}:80 -d algo3_backend

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test_get_queue:
 	curl --location --request GET "${DOMAIN}:${PORT}/api/discord/v1/help_queue"
 
 build_docker:
-	docker build -t algo3_backend . --no-cache
+	docker build -t algo3_backend .
 
 run_docker:
 	docker run --rm -p ${FROM}:80 -d algo3_backend

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test_get_queue:
 	curl --location --request GET "${DOMAIN}:${PORT}/api/discord/v1/help_queue"
 
 build_docker:
-	docker build -t algo3_backend .
+	docker build -t algo3_backend . --no-cache
 
 run_docker:
 	docker run --rm -p ${FROM}:80 algo3_backend -d

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ DOMAIN?=localhost
 PORT?=8080
 GROUP?=0
 HELPER?=Ayudante
+FROM?=${PORT}
 
 run:
 	cargo run --release -- --port=${PORT}
@@ -23,3 +24,9 @@ test_clear:
 
 test_get_queue:
 	curl --location --request GET "${DOMAIN}:${PORT}/api/discord/v1/help_queue"
+
+build_docker:
+	docker build -t algo3_backend .
+
+run_docker:
+	docker run --rm -p ${FROM}:80 algo3_backend -d

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ source "$HOME/.cargo/env"
 Ejecutar el siguiente comando compilará y ejecutará el binario que estará escuchando requests en el puerto `8080` en `localhost` por default (en un Docker Container).
 
 ```bash
-make build_docker && make run_docker
+make run_docker
 ```
 
 La segunda directiva admite la opción `FROM` que por defecto es `8080` y representa al port que al que se hace forwarding.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,15 @@ source "$HOME/.cargo/env"
 
 ## Build and Run
 
-Ejecutar el siguiente comando compilará y ejecutará el binario que estará escuchando requests en el puerto `8080` en `localhost` por default.
+Ejecutar el siguiente comando compilará y ejecutará el binario que estará escuchando requests en el puerto `8080` en `localhost` por default (en un Docker Container).
+
+```bash
+make build_docker && make run_docker
+```
+
+La segunda directiva admite la opción `FROM` que por defecto es `8080` y representa al port que al que se hace forwarding.
+
+Ejecutar el siguiente comando compilará y ejecutará el binario que estará escuchando requests en el puerto `8080` en `localhost` por default (localmente).
 
 ```bash
 make run

--- a/src/web_server.rs
+++ b/src/web_server.rs
@@ -46,9 +46,9 @@ pub enum HelpQueueRequest {
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 pub struct ServerArguments {
-    #[clap(short, long, value_parser, default_value = "http://127.0.0.1")]
+    #[clap(short, long, value_parser, default_value = "http://0.0.0.0")]
     domain: String,
-    #[clap(short, long, value_parser, default_value_t = 8080)]
+    #[clap(short, long, value_parser, default_value_t = 80)]
     port: u16,
 }
 
@@ -64,8 +64,8 @@ impl Clone for ServerArguments {
 impl Default for ServerArguments {
     fn default() -> Self {
         Self {
-            domain: "http://127.0.0.1".to_string(),
-            port: 8080,
+            domain: "http://0.0.0.0".to_string(),
+            port: 80,
         }
     }
 }
@@ -120,7 +120,7 @@ impl WebServer {
         tokio::spawn(async move {
             // Start the server.
             println!("\n🌐 Server is running at {}:{}\n", args.domain, args.port);
-            warp::serve(routes).run(([127, 0, 0, 1], args.port)).await;
+            warp::serve(routes).run(([0, 0, 0, 0], args.port)).await;
         })
     }
 


### PR DESCRIPTION
## Motivación

Necesitamos poder hacer buildeos desde una máquina común para evitar posibles problemas de incompatibilidades entre sistemas operativos y falta de dependencias.

## Build and Run

Ejecutar el siguiente comando compilará y ejecutará el binario que estará escuchando requests en el puerto `8080` en `localhost` por default (en un Docker Container).

```bash
make run_docker FROM=port
```

donde *port* es el puerto local que se forwardea al expuesto en el container. Por defecto es `8080`.